### PR TITLE
Add a "numbers" endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,31 @@
             align-items: center;
             height: 100vh;
             margin: 0;
+            background-color: #f0f0f0;
+        }
+
+        .content {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            background-color: #ffffff;
+            padding: 20px;
+            border-radius: 5px;
         }
     </style>
+    <script>
+        async function getNumber() {
+            const response = await fetch('/api/numbers');
+            const number = await response.text();
+            document.getElementById('numberDisplay').innerHTML = number;
+        }
+    </script>
 </head>
 <body>
-    <p>"All we have to decide is what to do with the time that is given to us." - Gandalf</p>
+    <div class="content">
+        <p>"All we have to decide is what to do with the time that is given to us." - Gandalf</p>
+        <button onclick="getNumber()">Get random number</button>
+        <p id="numberDisplay"></p>
+    </div>
 </body>
 </html>

--- a/main.go
+++ b/main.go
@@ -2,12 +2,22 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
+	"strconv"
+	"time"
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "index.html")
+	})
+
+	http.HandleFunc("/api/numbers", func(w http.ResponseWriter, r *http.Request) {
+		randomNumber := rand.Intn(24) + 14
+		fmt.Fprint(w, strconv.Itoa(randomNumber))
 	})
 
 	fmt.Println("Serving on port 8080")


### PR DESCRIPTION
Added a new "/api/numbers" endpoint in main.go that returns a random integer between 14 and 37.
Updated index.html with a content section with a slightly different background color and modified the button to make a request to the new endpoint. The result is displayed in the body of the page.

Resolves #15