### PR TITLE
initialize simple oauth app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.16
+    WORKDIR /app
+    COPY . .
+    RUN go mod init simple-oauth-app
+    RUN go mod tidy
+    RUN go build -o simple-oauth-app
+    EXPOSE 8080
+    CMD [ "./simple-oauth-app" ]
+    
+
+  -

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Simple OAuth App
+
+    A simple app demonstrating OAuth2 authentication with GitHub.
+
+    ## Running the Program
+
+    ### With Go
+
+    1. Set your environment variables with your GitHub OAuth app credentials:
+
+    
+    export OAUTH2_CLIENT_ID=your_client_id
+    export OAUTH2_CLIENT_SECRET=your_client_secret
+    
+
+    2. Run the server:
+
+    
+    go run main.go
+    
+
+    ### With Docker
+
+    1. Build the Docker image:
+
+    
+    docker build -t simple-oauth-app .
+    
+
+    2. Run the Docker container:
+
+    
+    docker run -d -p 8080:8080 --env OAUTH2_CLIENT_ID=your_client_id --env OAUTH2_CLIENT_SECRET=your_client_secret simple-oauth-app

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>OAuth App</title>
+        <style>
+            body {
+                font-family: sans-serif;
+                background-color: #f5f5f5;
+            }
+            .container {
+                background-color: #fefefe;
+                border-radius: 5px;
+                box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+                max-width: 800px;
+                margin: 40px auto;
+                padding: 20px;
+            }
+            h1 {
+                color: #4a4a4a;
+                font-family: "Arial", sans-serif;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container">
+            <h1>Welcome to our Product</h1>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatem repudiandae molestias cumque nemo eum maxime distinctio quo aliquam!</p>
+        </div>
+    </body>
+    </html>
+    
+
+  -

--- a/main.go
+++ b/main.go
@@ -1,0 +1,55 @@
+package main
+
+    import (
+        "io/ioutil"
+        "log"
+        "net/http"
+        "os"
+
+        "golang.org/x/oauth2"
+        "golang.org/x/oauth2/github"
+    )
+
+    var (
+        githubOauthConfig = &oauth2.Config{
+            RedirectURL:  "http://localhost:8080/oauth2/github/callback",
+            ClientID:     os.Getenv("OAUTH2_CLIENT_ID"),
+            ClientSecret: os.Getenv("OAUTH2_CLIENT_SECRET"),
+            Scopes:       []string{},
+            Endpoint:     github.Endpoint,
+        }
+    )
+
+    func main() {
+        http.HandleFunc("/", handleIndex)
+        http.HandleFunc("/oauth2/github/login", handleGithubLogin)
+        http.HandleFunc("/oauth2/github/callback", handleGithubCallback)
+
+        http.ListenAndServe(":8080", nil)
+    }
+
+    func handleIndex(w http.ResponseWriter, r *http.Request) {
+        file, _ := ioutil.ReadFile("index.html")
+        w.Header().Set("Content-Type", "text/html")
+        w.Write(file)
+    }
+
+    func handleGithubLogin(w http.ResponseWriter, r *http.Request) {
+        url := githubOauthConfig.AuthCodeURL("state", oauth2.AccessTypeOnline)
+        http.Redirect(w, r, url, http.StatusFound)
+    }
+
+    func handleGithubCallback(w http.ResponseWriter, r *http.Request) {
+        code := r.URL.Query().Get("code")
+        token, err := githubOauthConfig.Exchange(r.Context(), code)
+
+        if err != nil {
+            http.Error(w, "Failed to get token", http.StatusInternalServerError)
+            return
+        }
+
+        log.Printf("User authenticated. Access token: %s", token.AccessToken)
+    }
+    
+
+  -


### PR DESCRIPTION
I have created the main.go file to serve index.html and support OAuth2 authentication via GitHub. When the user is authenticated, the access token will be logged. The index.html file is a simple landing page for a product with specified styles. I have also added a Dockerfile to run the server from a container and included instructions to run the program with `go` and `docker` in the README.md.

Resolves #38